### PR TITLE
Export types from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   "exports": {
     ".": {
       "import": "./dist/mergician.esm.js",
-      "require": "./dist/mergician.cjs"
+      "require": "./dist/mergician.cjs",
+      "types": "./dist/mergician.d.ts"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
See [TypeScript #52363](https://github.com/microsoft/TypeScript/issues/52363) for further information

Importing mergician without types exported results in the following error when TypeScript `moduleResolution` config is set to `Bundler`:

```Could not find a declaration file for module 'mergician'. '/node_modules/mergician/dist/mergician.esm.js' implicitly has an 'any' type.

There are types at '/node_modules/mergician/dist/mergician.d.ts', but this result could not be resolved when respecting package.json "exports". The 'mergician' library may need to update its package.json or typings.```